### PR TITLE
fix: npm install failed on linux & set default activationEvent to onStartupFinished

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -340,7 +340,7 @@ class CloudIdeGenerator extends Generator {
         this.log('installing dependencies...');
         const pluginTargetPath = this.destinationPath(this.options.name);
         try {
-            this.spawnCommandSync('npm install', [], { cwd: pluginTargetPath });
+            this.spawnCommandSync('npm install', [], { cwd: pluginTargetPath, shell: true });
         } catch (error) {
             this.log(
                 `If an error occurs during the installation process, please try to execute command 'npm i' in the directory '${pluginTargetPath}'.`

--- a/templates/config/package.json
+++ b/templates/config/package.json
@@ -16,7 +16,7 @@
     ],
     "main": "dist/plugin.js",
     "activationEvents": [<% if(type === 'webview' || type === 'project-wizard') { %>
-        "*"<% } else { %> 
+        "onStartupFinished"<% } else { %> 
         "onCommand:plugin.sayHello"<% } %>
     ],<% if(type == 'simple') { %>
     "contributes": {


### PR DESCRIPTION
1. Fix the following error on linux
![image](https://github.com/huaweicloud/generator-cloudide-plugin/assets/33801132/957bddf9-2de4-4813-92e3-06b56fc980bd)

2. Set default activationEvent to onStartupFinished